### PR TITLE
Fix Xcode 14 style compile log extraction

### DIFF
--- a/xcactivitylog.py
+++ b/xcactivitylog.py
@@ -83,7 +83,7 @@ def extract_compile_log(path):
     for (type, value) in tokenizer(path):
         if type != TokenType.String: continue
         assert isinstance(value, str)
-        if not value.startswith("CompileSwiftSources "): continue
+        if not value.startswith(("CompileSwiftSources ", "SwiftDriver\\ Compilation ")): continue
         lines = value.splitlines()
         if len(lines) > 1:
             yield from iter(lines)


### PR DESCRIPTION
Fix `xcactivitylog.py` for Xcode 14 style log. `xcode-build-server postaction` doesn't work without this fix in Xcode 14.