### PR TITLE
Unescaping file paths found in .compile

### DIFF
--- a/compile_database.py
+++ b/compile_database.py
@@ -178,8 +178,8 @@ def CommandForSwiftInCompile(filename, compileFile, global_store):
                 for i in m
                 if "fileLists" in i and "command" in i
                 for l in i["fileLists"]
-                if os.path.isfile(l)
-                for f in getFileList(l, global_store.setdefault("filelist", {}))
+                if os.path.isfile(l.replace("\\", ""))
+                for f in getFileList(l.replace("\\", ""), global_store.setdefault("filelist", {}))
             )  # swift file lists
             info.update(
                 (i["file"].lower(), i["command"])  # now not use other argument, like cd


### PR DESCRIPTION
Compile commands that contain file paths with escaped spaces break when parsing `.compile`. For example:

`-Xcc /Users/charshep/Library/Developer/Xcode/DerivedData/Test_13_4_1-dnwylfechcmuvyhafmkbcvjjrmkh/Build/Intermediates.noindex/Test_13_4_1.build/Debug-iphonesimulator/Test_13_4_1\\ \\(iOS\\).build/Test_13_4_1-generated-files.hmap`

Without the fix `FlagsForSwift` returns the default

`["-sdk", "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/"]`

because the `FlagsForSwiftInCompile` fails. With the fix I see the expected flags parsed.

Note that it doesn't appear that the escaped "(" and ")" cause problems, just the spaces. I found this when I created a default iOS App with Xcode 13.4.1 and set it up with `xcode-build-server`. The same project created with XCode 14.1.0 does not generate path names with " (iOS) " in the name.

Not sure if this is the correct fix. Please disregard if it's not appropriate.

As always, thank you so much for making this project available and keeping it maintained.