### PR TITLE
Verbosity level setup

### DIFF
--- a/xclog_parser.py
+++ b/xclog_parser.py
@@ -109,6 +109,11 @@ class XcodeLogParser(object):
         echo(f"CompileSwiftModule {module['module_name']}")
         return module
 
+    def parse_swift_error(self, line: str):
+        if not line.startswith('/'): return
+        if not line.__contains__('error'): return
+        echo(line)
+
     def parse_swift_driver_module(self, line: str):
         # match cases 1:
         # SwiftDriver XXXDevEEUnitTest normal x86_64 com.apple.xcode.tools.swift.compiler (in target 'XXXDevEEUnitTest' from project 'XXXDev')
@@ -217,6 +222,7 @@ class XcodeLogParser(object):
         # @return Future or Item, None to skip it
         matcher = [
             self.parse_swift_driver_module,
+            self.parse_swift_error,
             self.parse_compile_swift_module,
             self.parse_c,
             self.parse_pch,

--- a/xclog_parser.py
+++ b/xclog_parser.py
@@ -5,7 +5,7 @@ import os
 import re
 import shlex
 import sys
-from typing import Iterator, List
+from typing import Iterator, List, Optional
 
 
 def echo(s):
@@ -111,12 +111,12 @@ class XcodeLogParser(object):
         return module
 
     def parse_swift_error(self, line: str):
-        regexp_str = r''
+        regexp_str: Optional[str] = None
         if not line.startswith('/'): return
         if self.verbosity == 1: regexp_str = r'\:\s+(error)\:'
         if self.verbosity == 2: regexp_str = r'\:\s+(error|warning)\:'
         if self.verbosity == 3: regexp_str = r'\:\s+(error|warning|note)\:'
-        if not re.search(regexp_str, line): return
+        if not (regexp_str and re.search(regexp_str, line)): return
         echo(line)
 
     def parse_swift_driver_module(self, line: str):


### PR DESCRIPTION
Here is the initial solution to pass compilation errors. It's quite straightforward and simple. It has the following output: 

```
/Users/user/BCS/ucf-ios/Packages/SomePackage/Sources/SomeTarget/TextField/Models/SomeSource.swift:21:14: error: value of type 'SomeTypeMoneyFieldModel' has no member 'balancePublisher'
```

However, there are a few caveats with the further implementation, the main one is that errors have multiline output within building logs, while the utility parser is implemented in a simple loop manner (which I believe is a reasonable decision), as a significant amount of redundant complexity would be added to the project otherwise [see example below].

For now I think the question that needs to be answered before proceeding with any further work — wether it's worth to modifying a parser engine to make it capable of handle multiline output or not?

Pros:
- It would provide a more user friendly error description, which is, in turn one of general features of Swift-lang.

Cons:
- The solution, even in its current state, does the job, while developing a highly polished UX for error handling could require significant effort (e.g. it would be nice to repeat occurred errors at the very end of a log's output) which, I believe, is not necessary in this case. 

So I'd rather keep it that simple than make things more complicated.

```
/Users/user/BCS/ucf-ios/Packages/SomePackage/Sources/SomeTarget/TextField/Models/SomeSource.swift:21:14: error: value of type 'SomeTypeMoneyFieldModel' has no member 'balancePublisher'
        self.balancePublisher = balancePublisher
        ~~~~ ^~~~~~~~~~~~~~~~

```

