### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,16 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        steps:
+        - name: Checkout
+          uses: actions/checkout@v3
+
+        - name: Create Release
+          uses: ncipollo/release-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 __pycache__/
-.*
-!.gitignore
 TODO.md
 tags

--- a/Readme.md
+++ b/Readme.md
@@ -88,3 +88,10 @@ if you found find definition or references is not work correctly, just build it 
 # More
 
 current implementation is basicly work, but may have some rough edges. Please report issue if you have any problem. If you want to help, can check the open issue list. PR is always welcome.
+
+# Development
+
+## Release new version
+1. Create a new tag with `git tag -a v0.1.0 -m "release 0.1.0"`
+2. Push tag with `git push origin v0.1.0`
+3. GitHub action will create release


### PR DESCRIPTION
One requirement for adding the xcode-build-tool to Homebrew is to have a stable version, as specified in the Homebrew documentation: https://docs.brew.sh/Acceptable-Formulae#stable-versions. In that PR, I've added a GitHub Action that will create a release when a new version tag is detected.

https://github.com/SolaWing/xcode-build-server/issues/35