### PR TITLE
Infer Xcode's SDK path dynamically

### DIFF
--- a/compile_database.py
+++ b/compile_database.py
@@ -23,9 +23,12 @@ XCODE_BASE_PATH = None
 def getXcodeBasePath():
     global XCODE_BASE_PATH
     if XCODE_BASE_PATH is None:
-        XCODE_BASE_PATH = subprocess.check_output(
-            ["xcode-select", "-p"]
-        ).rstrip().decode('utf8')
+        try:
+            XCODE_BASE_PATH = subprocess.check_output(
+                ["xcode-select", "-p"]
+            ).rstrip().decode('utf8')
+        except subprocess.CalledProcessError:
+            XCODE_BASE_PATH = '/Applications/Xcode.app/Contents/Developer'
     return XCODE_BASE_PATH
 
 

--- a/compile_database.py
+++ b/compile_database.py
@@ -17,6 +17,17 @@ cmd_split_pattern = re.compile(
     re.X,
 )
 
+XCODE_BASE_PATH = None
+
+
+def getXcodeBasePath():
+    global XCODE_BASE_PATH
+    if XCODE_BASE_PATH is None:
+        XCODE_BASE_PATH = subprocess.check_output(
+            ["xcode-select", "-p"]
+        ).rstrip().decode('utf8')
+    return XCODE_BASE_PATH
+
 
 def isProjectRoot(directory):
     return os.path.exists(os.path.join(directory, ".git"))
@@ -327,13 +338,13 @@ def InferFlagsForSwift(filename, compileFile, store):
         else:
             final_flags += [
                 "-sdk",
-                "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/",
+                os.path.join(getXcodeBasePath(), "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/"),
             ]
     if not final_flags:
         final_flags = [
             filename,
             "-sdk",
-            "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/",
+            os.path.join(getXcodeBasePath(), "Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/"),
         ]
 
     return final_flags


### PR DESCRIPTION
Currently, the argument passed to `swiftc` is hardcoded as `-sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/`. This causes SourceKit-LSP to fail if Xcode is installed in a different path (e.g., beta versions of Xcode). Instead of hardcoding the path, infer it dynamically using `xcode-select -p`.

The only potential issue this change could introduce is if the user has the Command Line Developer Tools (CLDT) set as the default rather than Xcode. However, I don't think that's problematic because:
- CLDT also has its own copy of `MacOSX.platform`.
- In my experience, Xcode updates `xcode-select` to its own path when it gets updated.
- I don't anticipate `xcode-select` reverting to CLDT, except perhaps if the user installs Homebrew using the installer script after installing Xcode.